### PR TITLE
Fix NullPointerException

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "io.github.cloudate9.passwordlogon"
-version = "1.3.5"
+version = "1.3.6"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/github/cloudate9/passwordlogon/PasswordLogOn.java
+++ b/src/main/java/io/github/cloudate9/passwordlogon/PasswordLogOn.java
@@ -88,12 +88,13 @@ public class PasswordLogOn extends JavaPlugin {
     private void giveResistance() {
         BukkitScheduler scheduler = getServer().getScheduler();
         scheduler.scheduleSyncRepeatingTask(Utils.plugin, () -> {
-            for (UUID u : Utils.noPasswordEntered.keySet()) {
+            Iterator<UUID> uuids = Utils.noPasswordEntered.keySet().iterator();
+            while (uuids.hasNext()) {
+                UUID u = uuids.next();
                 Player p = Bukkit.getPlayer(u);
 
-                if (p != null) {
-                    p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 61, 254));
-                }
+                if (p == null) uuids.remove();
+                else p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 61, 254));
             }
         }, 0, 60);
     }

--- a/src/main/java/io/github/cloudate9/passwordlogon/PasswordLogOn.java
+++ b/src/main/java/io/github/cloudate9/passwordlogon/PasswordLogOn.java
@@ -89,8 +89,11 @@ public class PasswordLogOn extends JavaPlugin {
         BukkitScheduler scheduler = getServer().getScheduler();
         scheduler.scheduleSyncRepeatingTask(Utils.plugin, () -> {
             for (UUID u : Utils.noPasswordEntered.keySet()) {
-                //noinspection ConstantConditions, if player with UUID u leaves, it would have been removed.
-                Bukkit.getPlayer(u).addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 61, 254));
+                Player p = Bukkit.getPlayer(u);
+
+                if (p != null) {
+                    p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 61, 254));
+                }
             }
         }, 0, 60);
     }


### PR DESCRIPTION
Encountered a bot, probably. Player instantly dropped connection, causing tons of `java.lang.NullPointerException`s.

<details>
  <summary>Log</summary>

  ```
  [23:50:01 INFO]: UUID of player INETDataSurveyWT is 67d906b2-a2e6-3d85-9293-7d427cc4ce42
  [23:50:02 INFO]: INETDataSurveyWT lost connection: Disconnected
  [23:50:02 INFO]: INETDataSurveyWT left the game
  [23:50:03 WARN]: [PasswordLogOn] Task #11 for PasswordLogOn v1.3.5 generated an exception
  java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Player.addPotionEffect(org.bukkit.potion.PotionEffect)" because the return value of "org.bukkit.Bukkit.getPlayer(java.util.UUID)" is null
          at io.github.cloudate9.passwordlogon.PasswordLogOn.lambda$giveResistance$0(PasswordLogOn.java:93) ~[PasswordLogOn-1.3.5.jar:?]
          at org.bukkit.craftbukkit.v1_18_R2.scheduler.CraftTask.run(CraftTask.java:101) ~[paper-1.18.2.jar:git-Paper-359]
          at org.bukkit.craftbukkit.v1_18_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[paper-1.18.2.jar:git-Paper-359]
          at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1531) ~[paper-1.18.2.jar:git-Paper-359]
          at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:483) ~[paper-1.18.2.jar:git-Paper-359]
          at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1455) ~[paper-1.18.2.jar:git-Paper-359]
          at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1225) ~[paper-1.18.2.jar:git-Paper-359]
          at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.18.2.jar:git-Paper-359]
          at java.lang.Thread.run(Thread.java:833) ~[?:?]
  ```
</details>